### PR TITLE
populate transaction history before sync begins

### DIFF
--- a/cw_decred/lib/wallet.dart
+++ b/cw_decred/lib/wallet.dart
@@ -89,7 +89,7 @@ abstract class DecredWalletBase
 
   Future<void> init() async {
     updateBalance();
-
+    updateTransactionHistory();
     await walletAddresses.init();
   }
 
@@ -101,6 +101,10 @@ abstract class DecredWalletBase
     // final decoded = json.decode(res);
     // final hash = decoded["hash"] ?? "";
     updateBalance();
+    updateTransactionHistory();
+  }
+
+  void updateTransactionHistory() async {
     var from = 0;
     while (true) {
       // Transactions are returned from newest to oldest. Loop fetching 5 txn


### PR DESCRIPTION
Transaction history is initially empty when the app loads, until the wallet is synced before transactions are fetched. This fetches transactions earlier and updates when the wallet becomes synced.