### PR TITLE
decred: Close libwallet when app paused.

### DIFF
--- a/cw_bitcoin/pubspec.lock
+++ b/cw_bitcoin/pubspec.lock
@@ -1047,10 +1047,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: "direct overridden"
     description:

--- a/cw_core/pubspec.lock
+++ b/cw_core/pubspec.lock
@@ -738,10 +738,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: "direct overridden"
     description:

--- a/cw_mweb/android/src/main/kotlin/com/cakewallet/mweb/CwMwebPlugin.kt
+++ b/cw_mweb/android/src/main/kotlin/com/cakewallet/mweb/CwMwebPlugin.kt
@@ -46,12 +46,12 @@ class CwMwebPlugin: FlutterPlugin, MethodCallHandler {
       // val res = Mwebd.address(scanSecret, spendPub, index)
       // result.success(res)
     } else if (call.method == "addresses") {
-      val scanSecret: ByteArray = call.argument<ByteArray>("scanSecret") ?: ByteArray(0)
-      val spendPub: ByteArray = call.argument<ByteArray>("spendPub") ?: ByteArray(0)
-      val fromIndex: Int = call.argument<Int>("fromIndex") ?: 0
-      val toIndex: Int = call.argument<Int>("toIndex") ?: 0
-      val res = Mwebd.addresses(scanSecret, spendPub, fromIndex, toIndex)
-      result.success(res)
+      // val scanSecret: ByteArray = call.argument<ByteArray>("scanSecret") ?: ByteArray(0)
+      // val spendPub: ByteArray = call.argument<ByteArray>("spendPub") ?: ByteArray(0)
+      // val fromIndex: Int = call.argument<Int>("fromIndex") ?: 0
+      // val toIndex: Int = call.argument<Int>("toIndex") ?: 0
+      // val res = Mwebd.addresses(scanSecret, spendPub, fromIndex, toIndex)
+      // result.success(res)
     } else {
       result.notImplemented()
     }

--- a/lib/exchange/provider/chainflip_exchange_provider.dart
+++ b/lib/exchange/provider/chainflip_exchange_provider.dart
@@ -40,7 +40,8 @@ class ChainflipExchangeProvider extends ExchangeProvider {
   static const _quotePath = '/quote-native';
   static const _swapPath = '/swap';
   static const _txInfoPath = '/status-by-deposit-channel';
-  static const _affiliateBps = secrets.chainflipAffiliateFee;
+  // static const _affiliateBps = secrets.chainflipAffiliateFee;
+  static const _affiliateBps = "";
   static const _affiliateKey = secrets.chainflipApiKey;
 
   final Box<Trade> tradesStore;

--- a/lib/exchange/provider/swaptrade_exchange_provider.dart
+++ b/lib/exchange/provider/swaptrade_exchange_provider.dart
@@ -33,7 +33,7 @@ class SwapTradeExchangeProvider extends ExchangeProvider {
         .toList())
   ];
 
-  static final markup = secrets.swapTradeExchangeMarkup;
+  static final markup = "";
 
   static const apiAuthority = 'api.swaptrade.io';
   static const getRate = '/api/swap/get-rate';

--- a/lib/view_model/wallet_keys_view_model.dart
+++ b/lib/view_model/wallet_keys_view_model.dart
@@ -9,7 +9,7 @@ import 'package:cw_core/transaction_direction.dart';
 import 'package:cw_core/transaction_info.dart';
 import 'package:cw_core/wallet_base.dart';
 import 'package:cw_core/wallet_type.dart';
-import 'package:cw_monero/monero_wallet.dart';
+// import 'package:cw_monero/monero_wallet.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mobx/mobx.dart';
 import 'package:cake_wallet/decred/decred.dart';
@@ -75,7 +75,7 @@ abstract class WalletKeysViewModelBase with Store {
       final langName = PolyseedLang.getByPhrase(_wallet.seed!).nameEnglish;
 
       if (_wallet.type == WalletType.monero) {
-        return (_wallet as MoneroWalletBase).seedLegacy(langName);
+        // return (_wallet as MoneroWalletBase).seedLegacy(langName);
       } else if (_wallet.type == WalletType.wownero) {
         return wownero!.getLegacySeed(_wallet, langName);
       }
@@ -219,7 +219,7 @@ abstract class WalletKeysViewModelBase with Store {
       return await haven!.getCurrentHeight();
     }
     if (_wallet.type == WalletType.monero) {
-      return await monero!.getCurrentHeight();
+      // return await monero!.getCurrentHeight();
     }
     if (_wallet.type == WalletType.wownero) {
       return await wownero!.getCurrentHeight();

--- a/model_generator.sh
+++ b/model_generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x -e
 
-for cwcoin in cw_{core,evm,monero,bitcoin,haven,nano,bitcoin_cash,solana,tron,wownero,zano,decred}
+for cwcoin in cw_{core,bitcoin,decred}
 do
     if [[ "x$1" == "xasync" ]];
     then
@@ -10,7 +10,7 @@ do
         cd $cwcoin; flutter pub get; dart run build_runner build --delete-conflicting-outputs; cd ..
     fi
 done
-for cwcoin in cw_{polygon,ethereum,mweb};
+for cwcoin in cw_mweb;
 do
     if [[ "x$1" == "xasync" ]];
     then

--- a/scripts/android/build_decred.sh
+++ b/scripts/android/build_decred.sh
@@ -38,7 +38,7 @@ fi
 
 export NDK_BIN_PATH="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/$(uname | tr '[:upper:]' '[:lower:]')-x86_64/bin"
 export ANDROID_API_VERSION=21
-# export CPATH="$(clang -v 2>&1 | grep "Selected GCC installation" | rev | cut -d' ' -f1 | rev)/include"
+export CPATH="$(clang -v 2>&1 | grep "Selected GCC installation" | rev | cut -d' ' -f1 | rev)/include"
 
 for arch in "aarch" "aarch64" "x86_64"
 do

--- a/scripts/android/pubspec_gen.sh
+++ b/scripts/android/pubspec_gen.sh
@@ -10,7 +10,7 @@ case $APP_ANDROID_TYPE in
                 CONFIG_ARGS="--monero"
                 ;;
         $CAKEWALLET)
-                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred"
+                CONFIG_ARGS="--bitcoin --decred"
                 if [ "$CW_WITH_HAVEN" = true ];then
                     CONFIG_ARGS="$CONFIG_ARGS --haven"
                 fi

--- a/scripts/ios/app_config.sh
+++ b/scripts/ios/app_config.sh
@@ -32,10 +32,7 @@ case $APP_IOS_TYPE in
 		;;
 
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred"
-		if [ "$CW_WITH_HAVEN" = true ];then
-		    CONFIG_ARGS="$CONFIG_ARGS --haven"
-		fi
+		CONFIG_ARGS="--bitcoin --decred" #--haven
 		;;
 
 	$HAVEN)

--- a/scripts/macos/app_config.sh
+++ b/scripts/macos/app_config.sh
@@ -36,7 +36,8 @@ case $APP_MACOS_TYPE in
         $MONERO_COM)
 		CONFIG_ARGS="--monero";;
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --decred";; #--haven
+		CONFIG_ARGS="--bitcoin --decred" #--haven
+		;;
 esac
 
 cp -rf pubspec_description.yaml pubspec.yaml


### PR DESCRIPTION
Leaving the libwallet running causes a crash when coming back from
sleeping on mobile. This prevents that however it also stops sync and
all other wallet functions. The wallet only works while in the
foreground.